### PR TITLE
Modifying .gitignore for TypeScript development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,55 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# VSCode
+.vscode/
+
+# Deno
+.deno/
+deno.lock
+deno.json
+deno.jsonc
+
+# TypeScript / Node.js
+node_modules/
+dist/
+build/
+*.tsbuildinfo
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.npm
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
+# AWS CDK
+cdk.out/
+cdk.context.json
+.cdk.staging/
+cdk-assets.json
+.aws-sam/
+samconfig.toml
+.aws/
+aws-exports.js
+awsconfiguration.json
+amplifyconfiguration.json
+amplifyconfiguration.dart
+amplify-build-config.json
+amplify-gradle-config.json
+amplifytools.xcconfig
+.secret-*
+**/*.aws.json
+!package.json
+!package-lock.json
+!yarn.lock
+!pnpm-lock.yaml


### PR DESCRIPTION
Repo was originally setup for Python development. Modifying .gitignore to add artifacts for Deno/NodeJS/TypeScript/CDK development.